### PR TITLE
refactor: remove thiserror dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,6 @@ name = "rosu-map"
 version = "0.1.0"
 dependencies = [
  "test-log",
- "thiserror",
  "tracing",
 ]
 
@@ -156,26 +155,6 @@ name = "test-log-macros"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba277e77219e9eea169e8508942db1bf5d8a41ff2db9b20aab5a5aadc9fa25d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["osu", "parse", "beatmap", "decode"]
 categories = ["parser-implementations", "parsing"]
 
 [dependencies]
-thiserror = { version = "1.0.50" }
 tracing = { version = "0.1.40", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/src/beatmap.rs
+++ b/src/beatmap.rs
@@ -203,17 +203,19 @@ impl Default for Beatmap {
     }
 }
 
-/// All the ways that parsing a `.osu` file into [`Beatmap`] can fail.
-#[derive(Debug, thiserror::Error)]
-pub enum ParseBeatmapError {
-    #[error("failed to parse colors section")]
-    Colors(#[from] ParseColorsError),
-    #[error("failed to parse editor section")]
-    Editor(#[from] ParseEditorError),
-    #[error("failed to parse hit objects")]
-    HitOjects(#[from] ParseHitObjectsError),
-    #[error("failed to parse metadata section")]
-    Metadata(#[from] ParseMetadataError),
+thiserror! {
+    /// All the ways that parsing a `.osu` file into [`Beatmap`] can fail.
+    #[derive(Debug)]
+    pub enum ParseBeatmapError {
+        #[error("failed to parse colors section")]
+        Colors(#[from] ParseColorsError),
+        #[error("failed to parse editor section")]
+        Editor(#[from] ParseEditorError),
+        #[error("failed to parse hit objects")]
+        HitOjects(#[from] ParseHitObjectsError),
+        #[error("failed to parse metadata section")]
+        Metadata(#[from] ParseMetadataError),
+    }
 }
 
 /// The parsing state for [`Beatmap`] in [`DecodeBeatmap`].

--- a/src/format_version.rs
+++ b/src/format_version.rs
@@ -25,13 +25,15 @@ pub(crate) fn try_version_from_line(line: &str) -> ControlFlow<Result<i32, Parse
     ControlFlow::Break(res)
 }
 
-/// All the ways that parsing the format version can fail.
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum ParseVersionError {
-    #[error("failed to parse number")]
-    Number(#[from] ParseNumberError),
-    #[error("unknown file format")]
-    UnknownFileFormat,
+thiserror! {
+    /// All the ways that parsing the format version can fail.
+    #[derive(Debug)]
+    pub(crate) enum ParseVersionError {
+        #[error("failed to parse number")]
+        Number(#[from] ParseNumberError),
+        #[error("unknown file format")]
+        UnknownFileFormat,
+    }
 }
 
 #[cfg(test)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,5 +1,3 @@
-#[macro_export]
-#[doc(hidden)]
 macro_rules! section_keys {
     (
         $( #[$meta:meta] )?
@@ -38,4 +36,204 @@ macro_rules! section_keys {
             }
         }
     };
+}
+
+macro_rules! thiserror {
+	(
+		#[error( $desc:tt )]
+		$( #[ $error_attribute:meta ] )*
+		$vis:vis struct $error_type_name:ident
+			$( (
+				$(
+					$( #[ $tattr:ident ] )?
+					$tt:ty
+				),* $(,)?
+			) )?;
+	) => {
+		$( #[ $error_attribute ] )*
+		$vis struct $error_type_name $( ( $( $tt )* ))?;
+
+		impl ::std::fmt::Display for $error_type_name {
+			fn fmt(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+				formatter.write_str($desc)
+			}
+		}
+
+		impl ::std::error::Error for $error_type_name {
+			fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+				thiserror!( @STRUCTSOURCE self, $( ( $( $tt ),* ) )? )
+			}
+		}
+	};
+
+	(
+		$( #[ $error_attribute:meta ] )*
+		$vis:vis struct $error_type_name:ident
+			$( (
+				$(
+					$( #[ $tattr:ident ] )?
+					$tt:ty
+				),* $(,)?
+			) )?;
+	) => {
+		compile_error!("`#[error(\"...\")]` must be the first attribute");
+	};
+
+	(
+		@STRUCTSOURCE
+		$self_:ident,
+		(
+			#[ $source_or_from:meta ]
+			$t1:ty $( , $t_rest:ty )*
+		)
+	) => {
+		Some(&self.0 as _)
+    };
+
+    (
+		@STRUCTSOURCE
+		$self_:ident,
+		$( ( $( $tt:ty ),* ) )?
+	) => {
+		None
+	};
+
+	(
+		$( #[$error_attribute:meta] )*
+		$vis:vis enum $error_type_name:ident {
+			$(
+				#[error( $desc:tt )]
+				$variant_name:ident
+					$( {
+						$(
+							$( #[ $sattr:ident ] )?
+							$sf:ident: $st:ty
+						),* $(,)?
+					} )?
+					$( (
+						$(
+							$( #[ $tattr:ident ] )?
+							$tt:ty
+						),* $(,)?
+					) )?
+			),* $(,)?
+		}
+	) => {
+		$( #[ $error_attribute ] )*
+        $vis enum $error_type_name {
+            $(
+                $variant_name
+					$( {
+						$( $sf: $st ),*
+					} )?
+					$( (
+						$( $tt ),*
+					) )?
+            ),*
+		}
+
+		impl ::std::fmt::Display for $error_type_name {
+			fn fmt(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+				#![allow(irrefutable_let_patterns)]
+
+				$(
+					thiserror!(
+						@ENUMFMT
+						self,
+						formatter,
+						$desc,
+						$variant_name
+						$( { $( $sf: $st ),* } )?
+						$( ( $( $tt ),* ) )?
+					);
+				)*
+
+				unreachable!()
+			}
+		}
+
+		$(
+			thiserror!(
+				@ENUMFROM
+				$error_type_name,
+				$variant_name
+				$( {
+					$(
+						$( #[ $sattr ] )?
+						$sf: $st
+					),*
+				} )?
+				$( (
+					$(
+						$( #[ $tattr ] )?
+						$tt
+					),*
+				) )?
+			);
+		)*
+
+		impl ::std::error::Error for $error_type_name {
+			fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+				$(
+					thiserror!(
+						@ENUMSOURCE
+						self,
+						$variant_name
+						$( { $( $sf: $st ),* } )?
+						$( ( $( $tt ),* ) )?
+					);
+				)*
+
+				None
+			}
+		}
+	};
+
+	( @ENUMFMT $self_:ident, $fmt:ident, $desc:literal, $variant_name:ident ) => {
+        if let Self::$variant_name = $self_ {
+			return $fmt.write_str($desc);
+        }
+    };
+
+	( @ENUMFMT $self_:ident, $fmt:ident, $desc:literal, $variant_name:ident ( $t1:ty ) ) => {
+        if let Self::$variant_name(a) = $self_ {
+            return write!($fmt, concat!($desc, "{0:.0?}"), a);
+        }
+    };
+
+    ( @ENUMFROM $e:ident, $variant_name:ident ( #[from] $t:ty ) ) => {
+        impl From<$t> for $e {
+            fn from(x: $t) -> $e {
+                $e::$variant_name(x)
+            }
+        }
+    };
+
+    (
+		@ENUMFROM
+		$e:ident, $variant_name:ident
+		$( ( $( $( #[source] )? $tt:ty ),* ) )?
+		$( { $( $( #[source] )? $sf:ident: $st:ty ),* } )?
+	) => {};
+
+    (
+		@ENUMSOURCE
+		$self_:ident,
+		$variant_name:ident (
+			#[ $source_or_from:meta ]
+			$t1:ty $( , $t_rest:ty )*
+		)
+	) => {
+        if let Self::$variant_name(x, ..) = $self_ {
+            return Some(x as _);
+        }
+    };
+
+    (
+		@ENUMSOURCE
+		$self_:ident,
+		$variant_name:ident
+		$( ( $( $tt:ty ),* ) )?
+		$( { $( $sf:ident: $st:ty ),* } )?
+	) => {};
 }

--- a/src/section/colors/decode.rs
+++ b/src/section/colors/decode.rs
@@ -54,13 +54,15 @@ impl FromStr for ColorsKey {
     }
 }
 
-/// All the ways that parsing a `.osu` file into [`Colors`] can fail.
-#[derive(Debug, thiserror::Error)]
-pub enum ParseColorsError {
-    #[error("color specified in incorrect format (should be R,G,B or R,G,B,A)")]
-    IncorrectColor,
-    #[error("failed to parse number")]
-    Number(#[source] ParseNumberError),
+thiserror! {
+    /// All the ways that parsing a `.osu` file into [`Colors`] can fail.
+    #[derive(Debug)]
+    pub enum ParseColorsError {
+        #[error("color specified in incorrect format (should be R,G,B or R,G,B,A)")]
+        IncorrectColor,
+        #[error("failed to parse number")]
+        Number(#[source] ParseNumberError),
+    }
 }
 
 impl From<ParseIntError> for ParseColorsError {

--- a/src/section/difficulty.rs
+++ b/src/section/difficulty.rs
@@ -54,11 +54,13 @@ section_keys! {
     }
 }
 
-/// All the ways that parsing a `.osu` file into [`Difficulty`] can fail.
-#[derive(Debug, thiserror::Error)]
-pub enum ParseDifficultyError {
-    #[error("failed to parse number")]
-    Number(#[from] ParseNumberError),
+thiserror! {
+    /// All the ways that parsing a `.osu` file into [`Difficulty`] can fail.
+    #[derive(Debug)]
+    pub enum ParseDifficultyError {
+        #[error("failed to parse number")]
+        Number(#[from] ParseNumberError),
+    }
 }
 
 /// The parsing state for [`Difficulty`] in [`DecodeBeatmap`].

--- a/src/section/editor.rs
+++ b/src/section/editor.rs
@@ -51,11 +51,13 @@ section_keys! {
     }
 }
 
-/// All the ways that parsing a `.osu` file into [`Editor`] can fail.
-#[derive(Debug, thiserror::Error)]
-pub enum ParseEditorError {
-    #[error("failed to parse number")]
-    Number(#[from] ParseNumberError),
+thiserror! {
+    /// All the ways that parsing a `.osu` file into [`Editor`] can fail.
+    #[derive(Debug)]
+    pub enum ParseEditorError {
+        #[error("failed to parse number")]
+        Number(#[from] ParseNumberError),
+    }
 }
 
 /// The parsing state for [`Editor`] in [`DecodeBeatmap`].

--- a/src/section/events/decode.rs
+++ b/src/section/events/decode.rs
@@ -23,15 +23,17 @@ impl From<Events> for Beatmap {
     }
 }
 
-/// All the ways that parsing a `.osu` file into [`Events`] can fail.
-#[derive(Debug, thiserror::Error)]
-pub enum ParseEventsError {
-    #[error("failed to parse event type")]
-    EventType(#[from] ParseEventTypeError),
-    #[error("invalid line")]
-    InvalidLine,
-    #[error("failed to parse number")]
-    Number(#[from] ParseNumberError),
+thiserror! {
+    /// All the ways that parsing a `.osu` file into [`Events`] can fail.
+    #[derive(Debug)]
+    pub enum ParseEventsError {
+        #[error("failed to parse event type")]
+        EventType(#[from] ParseEventTypeError),
+        #[error("invalid line")]
+        InvalidLine,
+        #[error("failed to parse number")]
+        Number(#[from] ParseNumberError),
+    }
 }
 
 /// The parsing state for [`Events`] in [`DecodeBeatmap`].

--- a/src/section/events/mod.rs
+++ b/src/section/events/mod.rs
@@ -57,7 +57,9 @@ impl FromStr for EventType {
     }
 }
 
-/// Error when failing to parse an [`EventType`].
-#[derive(Debug, thiserror::Error)]
-#[error("invalid event type")]
-pub struct ParseEventTypeError;
+thiserror! {
+    #[error("invalid event type")]
+    /// Error when failing to parse an [`EventType`].
+    #[derive(Debug)]
+    pub struct ParseEventTypeError;
+}

--- a/src/section/general/decode.rs
+++ b/src/section/general/decode.rs
@@ -90,17 +90,19 @@ section_keys! {
     }
 }
 
-/// All the ways that parsing a `.osu` file into [`General`] can fail.
-#[derive(Debug, thiserror::Error)]
-pub enum ParseGeneralError {
-    #[error("failed to parse countdown type")]
-    CountdownType(#[from] ParseCountdownTypeError),
-    #[error("failed to parse mode")]
-    Mode(#[from] ParseGameModeError),
-    #[error("failed to parse number")]
-    Number(#[from] ParseNumberError),
-    #[error("failed to parse sample bank")]
-    SampleBank(#[from] ParseSampleBankError),
+thiserror! {
+    /// All the ways that parsing a `.osu` file into [`General`] can fail.
+    #[derive(Debug)]
+    pub enum ParseGeneralError {
+        #[error("failed to parse countdown type")]
+        CountdownType(#[from] ParseCountdownTypeError),
+        #[error("failed to parse mode")]
+        Mode(#[from] ParseGameModeError),
+        #[error("failed to parse number")]
+        Number(#[from] ParseNumberError),
+        #[error("failed to parse sample bank")]
+        SampleBank(#[from] ParseSampleBankError),
+    }
 }
 
 /// The parsing state for [`General`] in [`DecodeBeatmap`].

--- a/src/section/general/mod.rs
+++ b/src/section/general/mod.rs
@@ -14,10 +14,12 @@ pub enum GameMode {
     Mania,
 }
 
-/// Error when failing to parse a [`GameMode`].
-#[derive(Copy, Clone, Debug, PartialEq, Eq, thiserror::Error)]
-#[error("invalid game mode")]
-pub struct ParseGameModeError;
+thiserror! {
+    #[error("invalid game mode")]
+    /// Error when failing to parse a [`GameMode`].
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    pub struct ParseGameModeError;
+}
 
 impl FromStr for GameMode {
     type Err = ParseGameModeError;
@@ -71,7 +73,9 @@ impl FromStr for CountdownType {
     }
 }
 
-/// Error when failing to parse a [`CountdownType`].
-#[derive(Debug, thiserror::Error)]
-#[error("invalid countdown type")]
-pub struct ParseCountdownTypeError;
+thiserror! {
+    #[error("invalid countdown type")]
+    /// Error when failing to parse a [`CountdownType`].
+    #[derive(Debug)]
+    pub struct ParseCountdownTypeError;
+}

--- a/src/section/hit_objects/decode.rs
+++ b/src/section/hit_objects/decode.rs
@@ -130,29 +130,31 @@ impl From<HitObjects> for Beatmap {
     }
 }
 
-/// All the ways that parsing a `.osu` file into [`HitObjects`] can fail.
-#[derive(Debug, thiserror::Error)]
-pub enum ParseHitObjectsError {
-    #[error("failed to parse difficulty section")]
-    Difficulty(ParseDifficultyError),
-    #[error("failed to parse events section")]
-    Events(#[from] ParseEventsError),
-    #[error("failed to parse hit object type")]
-    HitObjectType(#[from] ParseHitObjectTypeError),
-    #[error("failed to parse hit sound type")]
-    HitSoundType(#[from] ParseHitSoundTypeError),
-    #[error("invalid line")]
-    InvalidLine,
-    #[error("repeat count is way too high")]
-    InvalidRepeatCount(i32),
-    #[error("failed to parse number")]
-    Number(#[from] ParseNumberError),
-    #[error("invalid sample bank")]
-    SampleBankInfo(#[from] ParseSampleBankInfoError),
-    #[error("failed to parse timing points")]
-    TimingPoints(#[from] ParseTimingPointsError),
-    #[error("unknown hit object type")]
-    UnknownHitObjectType(HitObjectType),
+thiserror! {
+    /// All the ways that parsing a `.osu` file into [`HitObjects`] can fail.
+    #[derive(Debug)]
+    pub enum ParseHitObjectsError {
+        #[error("failed to parse difficulty section")]
+        Difficulty(ParseDifficultyError),
+        #[error("failed to parse events section")]
+        Events(#[from] ParseEventsError),
+        #[error("failed to parse hit object type")]
+        HitObjectType(#[from] ParseHitObjectTypeError),
+        #[error("failed to parse hit sound type")]
+        HitSoundType(#[from] ParseHitSoundTypeError),
+        #[error("invalid line")]
+        InvalidLine,
+        #[error("repeat count is way too high")]
+        InvalidRepeatCount(i32),
+        #[error("failed to parse number")]
+        Number(#[from] ParseNumberError),
+        #[error("invalid sample bank")]
+        SampleBankInfo(#[from] ParseSampleBankInfoError),
+        #[error("failed to parse timing points")]
+        TimingPoints(#[from] ParseTimingPointsError),
+        #[error("unknown hit object type")]
+        UnknownHitObjectType(HitObjectType),
+    }
 }
 
 /// The parsing state for [`HitObjects`] in [`DecodeBeatmap`].

--- a/src/section/hit_objects/hit_samples.rs
+++ b/src/section/hit_objects/hit_samples.rs
@@ -170,10 +170,12 @@ impl TryFrom<i32> for SampleBank {
     }
 }
 
-/// Error when failing to parse a [`SampleBank`].
-#[derive(Copy, Clone, Debug, PartialEq, Eq, thiserror::Error)]
-#[error("invalid sample bank value")]
-pub struct ParseSampleBankError;
+thiserror! {
+    #[error("invalid sample bank value")]
+    /// Error when failing to parse a [`SampleBank`].
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    pub struct ParseSampleBankError;
+}
 
 /// The type of a hit sample.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
@@ -231,10 +233,12 @@ impl FromStr for HitSoundType {
     }
 }
 
-/// Error when failing to parse a [`HitSoundType`].
-#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
-#[error("invalid hit sound type")]
-pub struct ParseHitSoundTypeError(#[source] ParseIntError);
+thiserror! {
+    #[error("invalid hit sound type")]
+    /// Error when failing to parse a [`HitSoundType`].
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    pub struct ParseHitSoundTypeError(ParseIntError);
+}
 
 impl PartialEq<u8> for HitSoundType {
     fn eq(&self, other: &u8) -> bool {
@@ -368,11 +372,13 @@ impl SampleBankInfo {
     }
 }
 
-/// All the ways that parsing into [`SampleBankInfo`] can fail.
-#[derive(Debug, thiserror::Error)]
-pub enum ParseSampleBankInfoError {
-    #[error("missing info")]
-    MissingInfo,
-    #[error("failed to parse number")]
-    Number(#[from] ParseNumberError),
+thiserror! {
+    /// All the ways that parsing into [`SampleBankInfo`] can fail.
+    #[derive(Debug)]
+    pub enum ParseSampleBankInfoError {
+        #[error("missing info")]
+        MissingInfo,
+        #[error("failed to parse number")]
+        Number(#[from] ParseNumberError),
+    }
 }

--- a/src/section/hit_objects/mod.rs
+++ b/src/section/hit_objects/mod.rs
@@ -157,10 +157,12 @@ impl FromStr for HitObjectType {
     }
 }
 
-/// Error when failing to parse a [`HitObjectType`].
-#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
-#[error("invalid hit object type")]
-pub struct ParseHitObjectTypeError(#[source] ParseIntError);
+thiserror! {
+    #[error("invalid hit object type")]
+    /// Error when failing to parse a [`HitObjectType`].
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    pub struct ParseHitObjectTypeError(ParseIntError);
+}
 
 impl From<HitObjectType> for i32 {
     fn from(kind: HitObjectType) -> Self {

--- a/src/section/metadata.rs
+++ b/src/section/metadata.rs
@@ -71,11 +71,13 @@ section_keys! {
     }
 }
 
-/// All the ways that parsing a `.osu` file into [`Metadata`] can fail.
-#[derive(Debug, thiserror::Error)]
-pub enum ParseMetadataError {
-    #[error("failed to parse number")]
-    Number(#[from] ParseNumberError),
+thiserror! {
+    /// All the ways that parsing a `.osu` file into [`Metadata`] can fail.
+    #[derive(Debug)]
+    pub enum ParseMetadataError {
+        #[error("failed to parse number")]
+        Number(#[from] ParseNumberError),
+    }
 }
 
 /// The parsing state for [`Metadata`] in [`DecodeBeatmap`].

--- a/src/section/mod.rs
+++ b/src/section/mod.rs
@@ -62,10 +62,12 @@ impl Section {
     }
 }
 
-/// The error when failing to parse a section key.
-#[derive(Debug, thiserror::Error)]
-#[error("unknown key")]
-pub struct UnknownKeyError;
+thiserror! {
+    #[error("unknown key")]
+    /// The error when failing to parse a section key.
+    #[derive(Debug)]
+    pub struct UnknownKeyError;
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/section/timing_points/control_points/timing.rs
+++ b/src/section/timing_points/control_points/timing.rs
@@ -89,7 +89,9 @@ impl TryFrom<i32> for TimeSignature {
     }
 }
 
-/// Error when failing to parse a [`TimeSignature`].
-#[derive(Copy, Clone, Debug, PartialEq, Eq, thiserror::Error)]
-#[error("invalid time signature, must be positive integer")]
-pub struct TimeSignatureError;
+thiserror! {
+    #[error("invalid time signature, must be positive integer")]
+    /// Error when failing to parse a [`TimeSignature`].
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    pub struct TimeSignatureError;
+}

--- a/src/section/timing_points/decode.rs
+++ b/src/section/timing_points/decode.rs
@@ -225,23 +225,25 @@ impl ControlPoint<ControlPoints> for SamplePoint {
     }
 }
 
-/// All the ways that parsing a `.osu` file into [`TimingPoints`] can fail.
-#[derive(Debug, thiserror::Error)]
-pub enum ParseTimingPointsError {
-    #[error("failed to parse effect flags")]
-    EffectFlags(#[from] ParseEffectFlagsError),
-    #[error("failed to parse general section")]
-    General(#[from] ParseGeneralError),
-    #[error("invalid line")]
-    InvalidLine,
-    #[error("failed to parse number")]
-    Number(#[from] ParseNumberError),
-    #[error("failed to parse sample bank")]
-    SampleBank(#[from] ParseSampleBankError),
-    #[error("time signature error")]
-    TimeSignature(#[from] TimeSignatureError),
-    #[error("beat length cannot be NaN in a timing control point")]
-    TimingControlPointNaN,
+thiserror! {
+    /// All the ways that parsing a `.osu` file into [`TimingPoints`] can fail.
+    #[derive(Debug)]
+    pub enum ParseTimingPointsError {
+        #[error("failed to parse effect flags")]
+        EffectFlags(#[from] ParseEffectFlagsError),
+        #[error("failed to parse general section")]
+        General(#[from] ParseGeneralError),
+        #[error("invalid line")]
+        InvalidLine,
+        #[error("failed to parse number")]
+        Number(#[from] ParseNumberError),
+        #[error("failed to parse sample bank")]
+        SampleBank(#[from] ParseSampleBankError),
+        #[error("time signature error")]
+        TimeSignature(#[from] TimeSignatureError),
+        #[error("beat length cannot be NaN in a timing control point")]
+        TimingControlPointNaN,
+    }
 }
 
 /// The parsing state for [`TimingPoints`] in [`DecodeBeatmap`].

--- a/src/section/timing_points/effect_flags.rs
+++ b/src/section/timing_points/effect_flags.rs
@@ -35,7 +35,9 @@ impl FromStr for EffectFlags {
     }
 }
 
-/// Error when failing to parse [`EffectFlags`].
-#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
-#[error("invalid effect flags")]
-pub struct ParseEffectFlagsError(#[source] ParseIntError);
+thiserror! {
+    #[error("invalid effect flags")]
+    /// Error when failing to parse [`EffectFlags`].
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    pub struct ParseEffectFlagsError(ParseIntError);
+}

--- a/src/util/parse_number.rs
+++ b/src/util/parse_number.rs
@@ -12,19 +12,21 @@ pub trait ParseNumber: Sized {
     fn parse_with_limits(s: &str, limit: Self) -> Result<Self, ParseNumberError>;
 }
 
-/// All the ways that parsing with [`ParseNumber`] can fail.
-#[derive(Debug, thiserror::Error)]
-pub enum ParseNumberError {
-    #[error("invalid float")]
-    InvalidFloat(#[from] num::ParseFloatError),
-    #[error("invalid integer")]
-    InvalidInteger(#[from] num::ParseIntError),
-    #[error("not a number")]
-    NaN,
-    #[error("value is too high")]
-    NumberOverflow,
-    #[error("value is too low")]
-    NumberUnderflow,
+thiserror! {
+    /// All the ways that parsing with [`ParseNumber`] can fail.
+    #[derive(Debug)]
+    pub enum ParseNumberError {
+        #[error("invalid float")]
+        InvalidFloat(#[from] num::ParseFloatError),
+        #[error("invalid integer")]
+        InvalidInteger(#[from] num::ParseIntError),
+        #[error("not a number")]
+        NaN,
+        #[error("value is too high")]
+        NumberOverflow,
+        #[error("value is too low")]
+        NumberUnderflow,
+    }
 }
 
 impl ParseNumber for i32 {


### PR DESCRIPTION
Replaces the `thiserror` dependency with a custom `thiserror` declarative macro.

This removes `syn`, `quote`, and `proc-macro2` from the default dependency tree.