### PR TITLE
fix: prevent oor indexing

### DIFF
--- a/src/section/hit_objects/decode.rs
+++ b/src/section/hit_objects/decode.rs
@@ -287,7 +287,10 @@ impl HitObjectsState {
             }
         }
 
-        self.vertices[0].path_type = Some(path_type);
+        self.vertices
+            .get_mut(0)
+            .ok_or(ParseHitObjectsError::InvalidLine)?
+            .path_type = Some(path_type);
 
         let mut start_idx = 0;
         let mut end_idx = 0;


### PR DESCRIPTION
Fixes indexing which had the chance to cause a panic.

Found via [afl.rs](https://github.com/rust-fuzz/afl.rs) thanks to #3.